### PR TITLE
Add OpenAI assistant example for Google Docs

### DIFF
--- a/OpenAIEditor.gs
+++ b/OpenAIEditor.gs
@@ -1,0 +1,63 @@
+const OPENAI_API_KEY = 'YOUR_API_KEY_HERE';
+
+function onOpen() {
+  DocumentApp.getUi()
+    .createMenu('OpenAI Tools')
+    .addItem('Open Assistant', 'showSidebar')
+    .addToUi();
+}
+
+function showSidebar() {
+  const html = HtmlService.createHtmlOutputFromFile('Sidebar')
+    .setTitle('OpenAI Assistant');
+  DocumentApp.getUi().showSidebar(html);
+}
+
+function processPrompt(instructions) {
+  const doc = DocumentApp.getActiveDocument();
+  const body = doc.getBody();
+  const originalText = body.getText();
+
+  const prompt = `Apply the following instructions to the text and return the full updated document.\n\nInstructions:\n${instructions}\n\nDocument text:\n${originalText}`;
+  const newText = callChatGPT(prompt);
+
+  body.setText(newText);
+  logChange(originalText, newText);
+}
+
+function callChatGPT(prompt) {
+  const url = 'https://api.openai.com/v1/chat/completions';
+
+  const payload = {
+    model: 'gpt-4',
+    messages: [{ role: 'user', content: prompt }],
+    temperature: 0.7
+  };
+
+  const options = {
+    method: 'post',
+    contentType: 'application/json',
+    headers: {
+      Authorization: `Bearer ${OPENAI_API_KEY}`
+    },
+    payload: JSON.stringify(payload)
+  };
+
+  const response = UrlFetchApp.fetch(url, options);
+  const json = JSON.parse(response.getContentText());
+  return json.choices[0].message.content;
+}
+
+function logChange(oldText, newText) {
+  const props = PropertiesService.getDocumentProperties();
+  const existing = props.getProperty('change_logs') || '';
+  const entry = [
+    'Time: ' + new Date().toISOString(),
+    '--- Old Text ---',
+    oldText,
+    '--- New Text ---',
+    newText,
+    ''
+  ].join('\n');
+  props.setProperty('change_logs', existing + entry + '\n');
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # openai-googleapps
+
+This repository contains an example Google Apps Script for integrating the OpenAI API with Google Docs.
+
+## Files
+
+- `OpenAIEditor.gs` – core Google Apps Script code.
+- `Sidebar.html` – HTML for the sidebar UI.
+
+## Usage
+
+1. Copy the contents of `OpenAIEditor.gs` and `Sidebar.html` into a new Google Apps Script project bound to a Google Doc.
+2. Replace `YOUR_API_KEY_HERE` in `OpenAIEditor.gs` with your OpenAI API key.
+3. Reload the document. A new **OpenAI Tools** menu will appear allowing you to open the assistant sidebar.
+4. Use the sidebar to enter instructions. The script sends the document text and your instructions to OpenAI and replaces the document body with the response.
+5. Changes are logged in the document properties under `change_logs` for simple version tracking.

--- a/Sidebar.html
+++ b/Sidebar.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <base target="_top">
+  </head>
+  <body>
+    <textarea id="instructions" style="width:100%;height:150px" placeholder="Describe how to update the document"></textarea>
+    <br>
+    <button onclick="send()">Send</button>
+    <script>
+      function send() {
+        var value = document.getElementById('instructions').value;
+        google.script.run.processPrompt(value);
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a Google Apps Script example that integrates OpenAI
- include sidebar HTML UI and Docs script
- document how to use the scripts in the README

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_687124edcd3883318d29fc3a921c192c