### PR TITLE
Enable Markdown based updates

### DIFF
--- a/OpenAIEditor.gs
+++ b/OpenAIEditor.gs
@@ -16,13 +16,18 @@ function showSidebar() {
 function processPrompt(instructions) {
   const doc = DocumentApp.getActiveDocument();
   const body = doc.getBody();
-  const originalText = body.getText();
 
-  const prompt = `Apply the following instructions to the text and return the full updated document.\n\nInstructions:\n${instructions}\n\nDocument text:\n${originalText}`;
-  const newText = callChatGPT(prompt);
+  // Convert the existing Google Doc to Markdown so formatting is preserved
+  const originalMarkdown = docToMarkdown(body);
 
-  body.setText(newText);
-  logChange(originalText, newText);
+  const prompt =
+    `Apply the following instructions to the Markdown text and return updated Markdown only.` +
+    `\n\nInstructions:\n${instructions}\n\nDocument Markdown:\n${originalMarkdown}`;
+  const newMarkdown = callChatGPT(prompt);
+
+  // Apply the returned Markdown back into the document
+  applyMarkdown(body, newMarkdown);
+  logChange(originalMarkdown, newMarkdown);
 }
 
 function callChatGPT(prompt) {
@@ -60,4 +65,108 @@ function logChange(oldText, newText) {
     ''
   ].join('\n');
   props.setProperty('change_logs', existing + entry + '\n');
+}
+
+// Convert the document body to Markdown, capturing basic formatting
+function docToMarkdown(body) {
+  const paragraphs = body.getParagraphs();
+  return paragraphs.map(paragraphToMarkdown).join('\n\n');
+}
+
+function paragraphToMarkdown(p) {
+  let text = textElementToMarkdown(p.editAsText());
+  switch (p.getHeading()) {
+    case DocumentApp.ParagraphHeading.HEADING1:
+      return '# ' + text;
+    case DocumentApp.ParagraphHeading.HEADING2:
+      return '## ' + text;
+    case DocumentApp.ParagraphHeading.HEADING3:
+      return '### ' + text;
+    default:
+      return text;
+  }
+}
+
+function textElementToMarkdown(te) {
+  const txt = te.getText();
+  let md = '';
+  let prevBold = false;
+  let prevItalic = false;
+  for (let i = 0; i < txt.length; i++) {
+    const curBold = te.isBold(i);
+    const curItalic = te.isItalic(i);
+    if (curBold !== prevBold) {
+      md += '**';
+      prevBold = curBold;
+    }
+    if (curItalic !== prevItalic) {
+      md += '_';
+      prevItalic = curItalic;
+    }
+    md += txt[i];
+  }
+  if (prevBold) md += '**';
+  if (prevItalic) md += '_';
+  return md;
+}
+
+// Apply Markdown text back into the document body
+function applyMarkdown(body, markdown) {
+  body.clear();
+  const lines = markdown.split(/\r?\n/);
+  lines.forEach(line => {
+    if (line.startsWith('# ')) {
+      body.appendParagraph(line.substring(2)).setHeading(DocumentApp.ParagraphHeading.HEADING1);
+    } else if (line.startsWith('## ')) {
+      body.appendParagraph(line.substring(3)).setHeading(DocumentApp.ParagraphHeading.HEADING2);
+    } else if (line.startsWith('### ')) {
+      body.appendParagraph(line.substring(4)).setHeading(DocumentApp.ParagraphHeading.HEADING3);
+    } else if (line.trim() === '') {
+      body.appendParagraph('');
+    } else {
+      appendInlineMarkdown(body.appendParagraph(''), line);
+    }
+  });
+}
+
+function appendInlineMarkdown(paragraph, text) {
+  const te = paragraph.editAsText();
+  const tokens = parseInlineMarkdown(text);
+  tokens.forEach(token => {
+    const start = te.getText().length;
+    te.insertText(start, token.text);
+    const end = te.getText().length - 1;
+    if (token.bold) te.setBold(start, end, true);
+    if (token.italic) te.setItalic(start, end, true);
+  });
+}
+
+function parseInlineMarkdown(text) {
+  const tokens = [];
+  let i = 0;
+  let bold = false;
+  let italic = false;
+  let chunk = '';
+  while (i < text.length) {
+    if (text.startsWith('**', i)) {
+      if (chunk) {
+        tokens.push({ text: chunk, bold, italic });
+        chunk = '';
+      }
+      bold = !bold;
+      i += 2;
+    } else if (text[i] === '_') {
+      if (chunk) {
+        tokens.push({ text: chunk, bold, italic });
+        chunk = '';
+      }
+      italic = !italic;
+      i += 1;
+    } else {
+      chunk += text[i];
+      i += 1;
+    }
+  }
+  if (chunk) tokens.push({ text: chunk, bold, italic });
+  return tokens;
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # openai-googleapps
 
 This repository contains an example Google Apps Script for integrating the OpenAI API with Google Docs.
+The script now converts your document to **Markdown** before sending it to OpenAI and applies the returned Markdown back into the document. This helps preserve basic formatting such as headings, bold and italic text.
 
 ## Files
 
@@ -12,5 +13,5 @@ This repository contains an example Google Apps Script for integrating the OpenA
 1. Copy the contents of `OpenAIEditor.gs` and `Sidebar.html` into a new Google Apps Script project bound to a Google Doc.
 2. Replace `YOUR_API_KEY_HERE` in `OpenAIEditor.gs` with your OpenAI API key.
 3. Reload the document. A new **OpenAI Tools** menu will appear allowing you to open the assistant sidebar.
-4. Use the sidebar to enter instructions. The script sends the document text and your instructions to OpenAI and replaces the document body with the response.
+4. Use the sidebar to enter instructions. The script converts the current document into Markdown, sends it along with your instructions to OpenAI and then applies the returned Markdown back into the document.
 5. Changes are logged in the document properties under `change_logs` for simple version tracking.


### PR DESCRIPTION
## Summary
- update README with Markdown support notes
- send/receive Markdown to preserve formatting
- convert docs to Markdown before calling OpenAI
- apply Markdown back to Google Docs

## Testing
- `npm test` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68712cdba6e88331bd070136f2d8de73