### PR TITLE
Handle images in doc to Markdown workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # openai-googleapps
 
 This repository contains an example Google Apps Script for integrating the OpenAI API with Google Docs.
-The script now converts your document to **Markdown** before sending it to OpenAI and applies the returned Markdown back into the document. This helps preserve basic formatting such as headings, bold and italic text.
+The script now converts your document to **Markdown** before sending it to OpenAI and applies the returned Markdown back into the document. This helps preserve basic formatting such as headings, bold and italic text. Embedded images and drawings are inserted back into their original positions.
 
 ## Files
 


### PR DESCRIPTION
## Summary
- capture embedded images and drawings when converting Docs to Markdown
- re-insert images when applying Markdown back to the document
- update README to note images/drawings are preserved

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68712f6ea078833186b4643ab81a8f1d