### PR TITLE
Fix compatibility with older DocumentApp API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # openai-googleapps
 
 This repository contains an example Google Apps Script for integrating the OpenAI API with Google Docs.
-The script no longer exports your document to Markdown. Instead it reads the document structure directly using `DocumentApp` and sends the plain text to OpenAI. When the response is received, the script updates the document using `Text.setText()` and `Text.setTextStyle()` so the original formatting is preserved. Embedded images and drawings are inserted back into their original positions.
+The script no longer exports your document to Markdown. Instead it reads the document structure directly using `DocumentApp` and sends the plain text to OpenAI. When the response is received, the script updates the document using `Text.setText()` and either `Text.setTextStyle()` or `Text.setAttributes()` so the original formatting is preserved. Embedded images and drawings are inserted back into their original positions.
 
 ## Files
 


### PR DESCRIPTION
## Summary
- support both `getTextStyle`/`setTextStyle` and the older `getAttributes`/`setAttributes`
- note new compatibility in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687565ca4ebc8331842c3250eefd704c