### PR TITLE
Fix API key storage vulnerability

### DIFF
--- a/OpenAIEditor.gs
+++ b/OpenAIEditor.gs
@@ -1,4 +1,12 @@
-const OPENAI_API_KEY = 'YOUR_API_KEY_HERE';
+/**
+ * Retrieve the OpenAI API key from script properties. This prevents the key
+ * from being stored directly in the source code where it could be exposed.
+ */
+function getApiKey() {
+  const key = PropertiesService.getScriptProperties().getProperty('OPENAI_API_KEY');
+  if (!key) throw new Error('OPENAI_API_KEY is not configured');
+  return key;
+}
 
 function onOpen() {
   DocumentApp.getUi()
@@ -43,7 +51,7 @@ function callChatGPT(prompt) {
     method: 'post',
     contentType: 'application/json',
     headers: {
-      Authorization: `Bearer ${OPENAI_API_KEY}`
+      Authorization: `Bearer ${getApiKey()}`
     },
     payload: JSON.stringify(payload)
   };

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The script no longer exports your document to Markdown. Instead it reads the doc
 ## Usage
 
 1. Copy the contents of `OpenAIEditor.gs` and `Sidebar.html` into a new Google Apps Script project bound to a Google Doc.
-2. Replace `YOUR_API_KEY_HERE` in `OpenAIEditor.gs` with your OpenAI API key.
+2. In the Apps Script editor, open **Project Settings** and add a script property named `OPENAI_API_KEY` containing your OpenAI API key. This keeps the key out of the source code.
 3. Reload the document. A new **OpenAI Tools** menu will appear allowing you to open the assistant sidebar.
 4. Use the sidebar to enter instructions. The script reads the document text directly, sends it along with your instructions to OpenAI, and then applies the returned text back into the document while restoring the original formatting.
 5. Changes are logged in the document properties under `change_logs` for simple version tracking.


### PR DESCRIPTION
## Summary
- avoid storing the OpenAI API key in source code
- document how to set the key using script properties

## Testing
- `trufflehog --json .`
- `semgrep scan --config auto .` *(failed: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687a77d967b08331b9dad2fcafd1a181